### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "author": "vadimkorr",
   "license": "Apache-2.0",
+  "type":"module",
   "bugs": {
     "url": "https://github.com/vadimkorr/easy-reactive/issues"
   },


### PR DESCRIPTION
added  "type":"module" to package.json

Running the svelte-carousel package was hissing at me. This should solve it. 

<img width="806" alt="Screenshot 2023-03-24 at 18 03 26" src="https://user-images.githubusercontent.com/52371939/227592627-d6f284ae-366e-464f-a644-ceea53ccf047.png">
